### PR TITLE
Changed python to python3 in Makefile. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ format:
 	black *.py
 
 test:
-	python -m pytest -vv --cov=hello test_hello.py
+	python3 -m pytest -vv --cov=hello test_hello.py


### PR DESCRIPTION
Changed `python` to `python3` in **Makefile**. 

When running `make test` it gave me the following error:

(venv) username@COMPUTER-XXXXXX:~/ml-ops/github-actions-demo$ `make test`
`python -m pytest -vv --cov=hello test_hello.py`
`make: execvp: python: Permission denied`
`make: *** [Makefile:23: test] Error 127`

Changing python to python3 in Makefile line 23 made it work.

This is my first ever pull request (took like 45 mins lol), so hopefully I'm doing this right.